### PR TITLE
adding 'coerce' to pd.to_timedelta

### DIFF
--- a/viewclust/slurm/sacct_jobs.py
+++ b/viewclust/slurm/sacct_jobs.py
@@ -88,7 +88,7 @@ def sacct_jobs(account_query, d_from, d_to='', debugging=False,
     # Fix jobs with day limits and convert to timedelta
     job_frame.update(job_frame.timelimit.loc[lambda x: x.str.contains('-')]
                      .str.replace('-', ' days '))
-    job_frame['timelimit'] = pd.to_timedelta(job_frame['timelimit'])
+    job_frame['timelimit'] = pd.to_timedelta(job_frame['timelimit'], errors='coerce')
 
     # Construct mem column
     job_frame['memHold'] = job_frame['reqmem'].map(


### PR DESCRIPTION
Lucas Nogueira referred me to this project in order to be able to retrieve results from jobs running on Beluga without parsing `sacct` outputs myself. I wanted to use `viewclust` on the cluster at Mila (contact me at guillaume.alain@mila.quebec if needed), but I got an error with the call to `pd.to_timedelta` (shown at the end of this text).

I don't know what the root cause of the problem is, but my best guess is that the "Unknown" returned by `sacct` are parsed differently. Maybe there's something about the string "days" in there, which is what the original line 89 intended to do. I don't know if our Slurm is configured in a different way to display dates that are over many days. Frankly, I just want those invalid values to show up as "NaT" as not be an obstacle.

My proposal is simply to add `errors='coerce'` in the right place.

```
>>> df = viewclust.slurm.sacct_jobs("mila", "2021-01-21T00:00:00")                                           

Traceback (most recent call last):                                                                           
  File "pandas/_libs/tslibs/timedeltas.pyx", line 264, in pandas._libs.tslibs.timedeltas.array_to_timedelta64  
  File "pandas/_libs/tslibs/timedeltas.pyx", line 431, in pandas._libs.tslibs.timedeltas.parse_timedelta_string 
ValueError: unit abbreviation w/o a number                    
   During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/mila/a/alaingui/Documents/code/venv38/lib/python3.8/site-packages/viewclust/slurm/sacct_jobs.py", line 91, in sacct_jobs
    job_frame['timelimit'] = pd.to_timedelta(job_frame['timelimit'])
  File "/home/mila/a/alaingui/Documents/code/venv38/lib/python3.8/site-packages/pandas/core/tools/timedeltas.py", line 114, in to_timedelta
    values = _convert_listlike(arg._values, unit=unit, errors=errors)
  File "/home/mila/a/alaingui/Documents/code/venv38/lib/python3.8/site-packages/pandas/core/tools/timedeltas.py", line 161, in _convert_listlike
    value = sequence_to_td64ns(arg, unit=unit, errors=errors, copy=False)[0]
  File "/home/mila/a/alaingui/Documents/code/venv38/lib/python3.8/site-packages/pandas/core/arrays/timedeltas.py", line 957, in sequence_to_td64ns
    data = objects_to_td64ns(data, unit=unit, errors=errors)
  File "/home/mila/a/alaingui/Documents/code/venv38/lib/python3.8/site-packages/pandas/core/arrays/timedeltas.py", line 1067, in objects_to_td64ns
    result = array_to_timedelta64(values, unit=unit, errors=errors)
  File "pandas/_libs/tslibs/timedeltas.pyx", line 274, in pandas._libs.tslibs.timedeltas.array_to_timedelta64
  File "pandas/_libs/tslibs/timedeltas.pyx", line 269, in pandas._libs.tslibs.timedeltas.array_to_timedelta64
  File "pandas/_libs/tslibs/timedeltas.pyx", line 214, in pandas._libs.tslibs.timedeltas.convert_to_timedelta64
  File "pandas/_libs/tslibs/timedeltas.pyx", line 682, in pandas._libs.tslibs.timedeltas.parse_iso_format_string
ValueError: Invalid ISO 8601 Duration format - Partition_Limit
```